### PR TITLE
Updates to WDL makefile and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,29 @@ The following Python packages are required:
 - `matplotlib`
 - `pyqt`
 
-You can install the required Python packages using:
-```bash
-pip install -r requirements.txt
-```
+1. **Create a Virtual Environment**:
+   If you don't have `venv` installed, you can install it with:
+   ```bash
+   sudo apt install python3-venv  # For Ubuntu
+   ```
+2. **Activate the Virtual Environment**:
+   Once you have created your virtual environment, you need to activate it to start using it. Activation sets up your shell to use the Python interpreter and libraries from the virtual environment instead of the global Python environment.  
+   
+   **Activation Commands**
+-  **On macOS and Linux**:
+   ```bash
+   source venv/bin/activate
+   ```
+
+3. **Install Required Packages**
+
+   Once your virtual environment is activated, you can install the necessary Python packages listed in the `requirements.txt` file.
+
+   **Installation Command**
+   Run the following command to install the required packages:
+   ```bash
+   pip install -r requirements.txt
+   ```
 
 ## Setup Instructions
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ The following Python packages are required:
    ```bash
    sudo apt install python3-venv  # For Ubuntu
    ```
+   **Create Command**
+   ```bash
+   python -m venv venv 
+   ```
+   
 2. **Activate the Virtual Environment**:
    Once you have created your virtual environment, you need to activate it to start using it. Activation sets up your shell to use the Python interpreter and libraries from the virtual environment instead of the global Python environment.  
    

--- a/demo/Makefile
+++ b/demo/Makefile
@@ -12,7 +12,7 @@
 #
 
 # set to path to gpp
-GPP       = /usr/local/bin/gpp
+GPP       = /usr/bin/gpp
 # set to path to wdl code
 WDLPATH   = ..
 # output for *.acf file

--- a/demo/Makefile
+++ b/demo/Makefile
@@ -12,7 +12,7 @@
 #
 
 # set to path to gpp
-GPP       = /usr/bin/gpp
+GPP       = /usr/local/bin/gpp
 # set to path to wdl code
 WDLPATH   = ..
 # output for *.acf file
@@ -29,38 +29,77 @@ MODEGEN   = $(WDLPATH)/modegenDriver.py
 I2A       = $(WDLPATH)/ini2acf.pl
 INCL      = -I$(CURDIR)
 
-SCAN_CDSFILE	= cat $(@F).conf | $(GPP) $(GFLAGS) $(INCL) | \
+# Global variable to store the filename
+FILE_NAME :=
+
+SCAN_CDSFILE = cat $(FILE_NAME).conf | $(GPP) $(GFLAGS) $(INCL) | \
 		awk -F= '{gsub(" |\t","",$$1)} $$1=="CDS_FILE"{print $$2}' | cut -d'"' -f2
-SCAN_MODFILE	= cat $(@F).conf | $(GPP) $(GFLAGS) $(INCL) | \
+SCAN_MODFILE = cat $(FILE_NAME).conf | $(GPP) $(GFLAGS) $(INCL) | \
 		awk -F= '{gsub(" |\t","",$$1)} $$1=="MODULE_FILE"{print $$2}' | cut -d'"' -f2
-SCAN_MODEFILE	= cat $(@F).conf | $(GPP) $(GFLAGS) $(INCL) | \
+SCAN_MODEFILE = cat $(FILE_NAME).conf | $(GPP) $(GFLAGS) $(INCL) | \
 		awk -F= '{gsub(" |\t","",$$1)} $$1=="MODE_FILE"{print $$2}' | cut -d'"' -f2
 
-F_TMP = $(@F)_TMP
+F_TMP = $(FILE_NAME)_TMP
 
-%:	;
+DEBUG ?= 0
+
+ifeq ($(DEBUG), 1)
+    debug_message = @echo "Debug: $(1)"
+else
+    debug_message = @true
+endif
+
+# Main rule for building the target
+%:
+	$(eval FILE_NAME := $(@F)) 
+	$(call debug_message, "Current filename: $(FILE_NAME)")
+	@$(MAKE) generate_wdl FILE_NAME=$(@F)
+	@$(MAKE) generate_script_states FILE_NAME=$(@F)
+	@$(MAKE) assemble_acf FILE_NAME=$(@F)
+
+# Rule for generating WDL
+generate_wdl: 
 	$(eval MODFILE := $(shell $(SCAN_MODFILE)))
-	@echo looking for MODULE_FILE = $(MODFILE) ...
-	@test -f $(@F).conf || echo $(@F).conf does not exist
-	@echo making $(F_TMP).wdl from $(@F).conf ...
-	@test -f $(@F).conf && cat $(@F).conf | $(SEQPARSER) - | $(GPP) $(GFLAGS) $(INCL) |  $(WDLPARSER) - > $(F_TMP).wdl
-	@echo making $(F_TMP).script, $(F_TMP).states from $(F_TMP).wdl ...
-	@test -f $(MODFILE) || echo $(MODFILE) does not exist
-	@test -f $(MODFILE) && echo $(F_TMP) | cat  - $(MODFILE) | $(GPP) $(GFLAGS) $(INCL) |  $(MODPARSER) -
-	@$(WAVGEN) $(F_TMP) $(PLOT)
-	@if [ $$? -eq 1 ]; then exit 1; fi
-	@echo assembling $(@F).acf ...
+	@echo "Looking for MODULE_FILE = $(MODFILE) ..."
+	@test -f $(FILE_NAME).conf || { echo "$(FILE_NAME).conf does not exist"; exit 1; }
+	$(call debug_message, "Found configuration file: $(FILE_NAME).conf")
+
+	@echo "Making $(F_TMP).wdl from $(FILE_NAME).conf ..."
+	@cat $(FILE_NAME).conf | $(SEQPARSER) - | $(GPP) $(GFLAGS) $(INCL) | $(WDLPARSER) - > $(F_TMP).wdl
+	$(call debug_message, "Created WDL file: $(F_TMP).wdl")
+
+	@echo "Making $(F_TMP).script and $(F_TMP).states from $(F_TMP).wdl ..."
+	@test -f $(MODFILE) || { echo "$(MODFILE) does not exist"; exit 1; }
+	$(call debug_message, "Found MODULE_FILE: $(MODFILE)")
+
+	@cat $(MODFILE) | $(GPP) $(GFLAGS) $(INCL) | $(MODPARSER) -
+	$(call debug_message, "Processed MODULE_FILE: $(MODFILE)")
+
+	@$(WAVGEN) $(F_TMP) $(PLOT) || { echo "Waveform generation failed"; exit 1; }
+	$(call debug_message, "Finished waveform generation for $(F_TMP) with plot: $(PLOT)")
+
+# Rule for generating script states
+generate_script_states:
+	@echo "Assembling $(FILE_NAME).acf ..."
 	$(eval CDSFILE := $(shell $(SCAN_CDSFILE)))
-	@echo looking for CDS_FILE = $(CDSFILE) ...
-	@test -f $(CDSFILE) || echo $(CDSFILE) does not exist
-	@echo assembling $(@F).acf file ...
-	@test -f $(CDSFILE) && cat $(@F).conf | $(INCPARSER) - | cat - $(CDSFILE) | $(GPP) $(GFLAGS) $(INCL) | \
+	$(call debug_message, "Looking for CDS_FILE = $(CDSFILE) ...")
+	@test -f $(CDSFILE) || { echo "$(CDSFILE) does not exist"; exit 1; }
+	$(call debug_message, "Preparing to assemble $(FILE_NAME).acf file using:")
+	$(call debug_message, "INCPARSER: $(INCPARSER)")
+	$(call debug_message, "CDSFILE: $(CDSFILE)")
+	$(call debug_message, "GPP Flags: $(GFLAGS)")
+	@echo "Assembling $(FILE_NAME).acf file ..."
+	@cat $(FILE_NAME).conf | $(INCPARSER) - | cat - $(CDSFILE) | $(GPP) $(GFLAGS) $(INCL) | \
 		cat - $(F_TMP).script $(F_TMP).modules $(F_TMP).states $(F_TMP).system | \
-		$(I2A) - > $(@F).acf
+		$(I2A) - > $(FILE_NAME).acf
+
+# Rule for assembling the ACF
+assemble_acf:
 	$(eval MODEFILE := $(shell $(SCAN_MODEFILE)))
-	@$(MODEGEN) $(MODEFILE) $(@F).acf
-	@if [ -d ".git" ]; \
-	then echo "inserting REV keyword ..."; $(WDLPATH)/insert_hash $(@F).acf; \
-	else echo "not a git archive, skipping REV keyword"; \
+	@$(MODEGEN) $(MODEFILE) $(FILE_NAME).acf
+	@if [ -d ".git" ]; then \
+		echo "Inserting REV keyword ..."; $(WDLPATH)/insert_hash $(FILE_NAME).acf; \
+	else \
+		echo "Not a git archive, skipping REV keyword"; \
 	fi
-	@echo "done"
+	@echo "Done"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 # Scientific computing and data analysis
-numpy
-scipy
+numpy==2.0.2
+scipy==1.13.1
 
 # Plotting and visualization
-matplotlib
+matplotlib==3.9.2
 
 # GUI development
-PyQt5
+PyQt5==5.15.11


### PR DESCRIPTION
Update the README to include the process of having a virtual environment and then installing the requirements

Requirements file updated with proper versions for the libraries needed for wdl

Makefile cleaned up to help with testing and debugging. 
To use debug mode:
`make DEBUG=1 Demo `
By default debug mode is off and all you will need to do is `make Demo` as usual.

Example output of debug:
```
%  make DEBUG=1 Demo
Debug:  Current filename: Demo
Looking for MODULE_FILE = Demo.mod ...
Debug:  Found configuration file: Demo.conf
Making Demo_TMP.wdl from Demo.conf ...
Debug:  Created WDL file: Demo_TMP.wdl
Making Demo_TMP.script and Demo_TMP.states from Demo_TMP.wdl ...
Debug:  Found MODULE_FILE: Demo.mod
Debug:  Processed MODULE_FILE: Demo.mod
Using MOD file: /Users/lotus/Projects/wdl/demo/Demo.mod
Loading signal mnemonics from /Users/lotus/Projects/wdl/demo/Demo.signals
Wrote script to Demo_TMP.script
Wrote states to Demo_TMP.states
Catalog of timing objects:
index  label                                type  exit  time [us]
-----------------------------------------------------------------
   0:  Main                             sequence   005 106563018.13
   1:  TestMode                         sequence   005   45800.09
   2:  TestRG                           sequence   009 10000206.25
   3:  TestSW                           sequence   009 30000618.77
   4:  GrabFrame                        sequence   014 106562560.10
   5:  GrabLine                         sequence   014   95732.14
   6:  GrabPixel                        sequence   014      44.06
   7:  MilliSec                         sequence   000    1000.02
   8:  Sec                              sequence   000 1000020.02
   9:  RawPixel                         waveform   000      10.00
  10:  wDelay1us                        waveform   000       1.00
  11:  wDelay1ms                        waveform   000    1000.00
  12:  wSampleDelay                     waveform   000      10.00
  13:  SerialShiftPixelA                waveform   007      35.00
  14:  SerialShiftPixelB                waveform   014      43.00
  15:  OnlyRG_Hi                        waveform   008       3.00
  16:  OnlyRG_Lo                        waveform   009       3.00
  17:  OnlySW_Hi                        waveform   015       3.00
  18:  OnlySW_Lo                        waveform   014       3.00
  19:  ParallelShiftMPP                 waveform   021    2400.00
  20:  ClampAC                          waveform   005      13.00
  21:  TestPhase                        waveform   005     458.00
  22:  RGHi                             waveform   008       3.00
  23:  wFrame                           waveform   023       0.01
  24:  wLine                            waveform   024       0.01
  25:  wPixel                           waveform   026       0.02
Debug:  Finished waveform generation for Demo_TMP with plot: False 
Assembling Demo.acf ...
Debug:  Looking for CDS_FILE = Demo.cds ...
Debug:  Preparing to assemble Demo.acf file using:
Debug:  INCPARSER: ../incParserDriver.py
Debug:  CDSFILE: Demo.cds
Debug:  GPP Flags: +c /* */ +c // 
 +c \n 
Assembling Demo.acf file ...
Modes appended to Demo.acf
Not a git archive, skipping REV keyword
Done
```