### PR TITLE
Use strings raw strings in regex prefixed with an r

### DIFF
--- a/wdl/modegen.py
+++ b/wdl/modegen.py
@@ -48,7 +48,7 @@ class Modegen:
         with open(self.modefile) as FILE:
             for line in FILE:
                 # look for headers
-                match = re.search("^\[(.*?)\]", line)
+                match = re.search(r"^\[(.*?)\]", line)
                 if match:
                     # initialize the KVpair entry
                     self.modeKVpair.update({match.group(1): {}})
@@ -57,7 +57,7 @@ class Modegen:
                     thismode = match.group(1)
                 else:
                     # look for key=value pairs, matching the LAST = on the line
-                    match = re.search("^(.+:.+)\s*=\s*(.+?)\n", line)
+                    match = re.search(r"^(.+:.+)\s*=\s*(.+?)\n", line)
                     if match:
                         # union will hold one of every key specified
                         self.union.update({match.group(1): None})
@@ -67,19 +67,19 @@ class Modegen:
                         )
                         # if the key is a non-empty TAPLINE setting,
                         # then increment self.taplines[thismode]
-                        if re.search('ACF:TAPLINE\d+="[\w,]+"', line):
+                        if re.search(r'ACF:TAPLINE\d+="[\w,]+"', line):
                             if thismode not in self.taplines:
                                 self.taplines.update({thismode: 1})
                             else:
                                 self.taplines[thismode] += 1
                         continue
                     # look for non key=value statements
-                    match = re.search("^(.+:[^=]+)\n", line)
+                    match = re.search(r"^(.+:[^=]+)\n", line)
                     if match:
                         self.modelist[thismode].append(match.group(1))
                         continue
                     # both matches failed - issue warning
-                    if re.search("[^\w]+", line[:-1]):
+                    if re.search(r"[^\w]+", line[:-1]):
                         print(
                             "WARNING: '%s' in %s not recognized as a "
                             "mode-setting statement" % (line[:-1], thismode)
@@ -98,15 +98,15 @@ class Modegen:
         with open(self.acffile) as ACF:
             for line in ACF:
                 # skip [MODE_X] statments
-                if re.search("^\w+:\w", line):
+                if re.search(r"^\w+:\w", line):
                     continue
                 # look for key=value pairs in ACF
-                match = re.search("^(.+)=(.+?)\n", line)
+                match = re.search(r"^(.+)=(.+?)\n", line)
                 if match:
                     ACFKEY = "ACF:" + match.group(1)
                     ACFVAL = match.group(2)
                     temp = ACFKEY.split('"')
-                    if re.search("PARAMETER", temp[0]):
+                    if re.search(r"PARAMETER", temp[0]):
                         ACFKEY = "ACF:" + temp[-1]
 
                     if ACFKEY in allkeys:
@@ -115,10 +115,10 @@ class Modegen:
                         # Parse the '%d' that typically shows up
                         # in 'ACF:PARAMETER'-keys
                         for unionkey in allkeys:  # do the reverse check
-                            if re.search("%d", unionkey):
+                            if re.search(r"%d", unionkey):
                                 # make regex from printf %d ONLY IF
                                 # it appears in the key
-                                unionregex = re.sub("%d", "(\d+)", unionkey)
+                                unionregex = re.sub(r"%d", r"(\d+)", unionkey)
                                 kmatch = re.search(unionregex, ACFKEY)
                                 if kmatch:
                                     try:
@@ -138,7 +138,7 @@ class Modegen:
         TheDefaultMode = self.modeKVpair["MODE_DEFAULT"]
         baddefault = False  # flag for bad default setting warning
         for key in TheDefaultMode:
-            match = re.search("^ACF:", key)
+            match = re.search(r"^ACF:", key)
             if not match:  # any key that isn't an ACF key
                 self.union[key] = TheDefaultMode[key]
             else:
@@ -155,13 +155,13 @@ class Modegen:
         for mode in self.modeKVpair:
             for key in self.modeKVpair[mode]:
                 # search the "ACF:" keys for "%d="
-                match = re.search("^ACF:.+?%d=(.+)", key)
+                match = re.search(r"^ACF:.+?%d=(.+)", key)
                 # NOTE: the above regex won't work for keys that do not
                 # have a "=" in them, ie, this will not work for LINE
                 # or MOD ACF statements, as they would not be unique
                 if match:
                     # now figure out which key in self.union this corresponds to
-                    keyregex = re.sub("%d", "(\d+)", key)
+                    keyregex = re.sub(r"%d", r"(\d+)", key)
                     for ukey in self.union:
                         kmatch = re.search(keyregex, ukey)
                         if kmatch:

--- a/wdl/timing_segment.py
+++ b/wdl/timing_segment.py
@@ -375,7 +375,7 @@ class TimingSegment(object):
                 EOL = True
                 if this_sub_call[0:3].upper() == "IF ":
                     # get the first word after IF...
-                    regexmatch = re.search("\w+\s+!?([\w]+)", this_sub_call)
+                    regexmatch = re.search(r"\w+\s+!?([\w]+)", this_sub_call)
                     this_param = regexmatch.group(1)
                     try:  # demo if this_param is an integer
                         int(this_param)
@@ -516,9 +516,9 @@ class TimingSegment(object):
             if len(seq_indx):
                 this_sub_call = self.sequenceDef[seq_indx[0]][1]
                 match = re.search(
-                    "(IF\s+(?P<N0>!)?(?P<P0>\w+)(?P<D0>--)?\s+)?"
-                    + "((?P<CMD>RETURN|GOTO|CALL)\s+(?P<TS>\w+)\(?)?"
-                    + "(\(?(?P<P1>\w+)?(?P<D1>--)?)\)?",
+                    r"(IF\s+(?P<N0>!)?(?P<P0>\w+)(?P<D0>--)?\s+)?"
+                    + r"((?P<CMD>RETURN|GOTO|CALL)\s+(?P<TS>\w+)\(?)?"
+                    + r"(\(?(?P<P1>\w+)?(?P<D1>--)?)\)?",
                     this_sub_call,
                 )
                 #  REGEX labels:

--- a/wdl/wavgen.py
+++ b/wdl/wavgen.py
@@ -92,7 +92,7 @@ def loadWDL(infile, outfile="/dev/null", verbose=1):
     with open(infile, "r") as f:
         for line in f:
             # look for mod file
-            match = re.search("^modulefile\s+([~\w./]+)\s*$", line)
+            match = re.search(r"^modulefile\s+([~\w./]+)\s*$", line)
             if match is not None:
                 ModFile = os.path.abspath(os.path.expanduser(match.group(1)))
                 wdl_file_did_not_specify_mod_file = False
@@ -116,25 +116,25 @@ def loadWDL(infile, outfile="/dev/null", verbose=1):
             if line == "":
                 continue
             # look for mod file
-            match = re.search("^modulefile\s+([~\w./]+)\s*$", line)
+            match = re.search(r"^modulefile\s+([~\w./]+)\s*$", line)
             if match is not None:
                 continue
             # look for signal file
-            match = re.search("^signalfile\s+([~\w./]+)\s*$", line)
+            match = re.search(r"^signalfile\s+([~\w./]+)\s*$", line)
             if match is not None:
                 __SignalFile__ = os.path.abspath(os.path.expanduser(match.group(1)))
                 if not os.path.isfile(__SignalFile__):
                     print("Signal file specified does not exist (%s)" % __SignalFile__)
                 continue
             # look for parameters
-            match = re.search("^parameter\s+(\w+)=(\d+)\s*$", line)
+            match = re.search(r"^parameter\s+(\w+)=(\d+)\s*$", line)
             if match is not None:
                 pname = match.group(1)
                 pval = int(match.group(2))
                 Parameters.update({pname: pval})
                 continue
             # look for constants
-            match = re.search("^constant\s+(\w+)=(\d+)\s*$", line)
+            match = re.search(r"^constant\s+(\w+)=(\d+)\s*$", line)
             if match is not None:
                 cname = match.group(1)
                 cval = int(match.group(2))
@@ -165,7 +165,7 @@ def loadWDL(infile, outfile="/dev/null", verbose=1):
                     thisTS.sequenceDef.append([ctr, line[:-1]])
                     ctr += 1
                 elif TStype == "waveform":
-                    match = re.search("(\d+)\s+(\d+)\s+(\d+)\s+([+-]?[\d\.]+)", line)
+                    match = re.search(r"(\d+)\s+(\d+)\s+(\d+)\s+([+-]?[\d\.]+)", line)
                     if match is not None:
                         # body of a waveform
                         time = int(match.group(1))
@@ -204,7 +204,7 @@ def loadWDL(infile, outfile="/dev/null", verbose=1):
                             )
                     else:
                         # handle the end line of a waveform.
-                        match = re.search("(\d+)\s+(\w+)", line)
+                        match = re.search(r"(\d+)\s+(\w+)", line)
                         thisTS.nperiods = int(match.group(1))
                         if thisTS.nperiods == 0:
                             print(
@@ -264,7 +264,7 @@ def __loadMod__(ModFile):  # subroutine of loadWDL()
     # btype = []
     with open(ModFile, "r") as f:
         for line in f:
-            match = re.search("^\s*SLOT\s+(\d+)\s+(\w+)\s{", line)
+            match = re.search(r"^\s*SLOT\s+(\d+)\s+(\w+)\s{", line)
             if match is not None:
                 thisSlotNum = int(match.group(1))
                 thisBoardLabel = match.group(2)
@@ -299,7 +299,7 @@ def __loadSignals__(__SignalFile__):  # subroutine of loadWDL()
     with open(__SignalFile__, "r") as f:
         for line in f:
             # look for signal file
-            match = re.search("^#define (\w+)\s+(\d+)\s+:\s+(\d+)", line)
+            match = re.search(r"^#define (\w+)\s+(\d+)\s+:\s+(\d+)", line)
             if match is not None:
                 signame = match.group(1)
                 sigslot = int(match.group(2))
@@ -749,7 +749,7 @@ class TimingSegment(object):
                 EOL = True
                 if this_sub_call[0:3].upper() == "IF ":
                     # get the first word after IF...
-                    regexmatch = re.search("\w+\s+!?([\w]+)", this_sub_call)
+                    regexmatch = re.search(r"\w+\s+!?([\w]+)", this_sub_call)
                     this_param = regexmatch.group(1)
                     try:  # demo if this_param is an integer
                         int(this_param)
@@ -893,9 +893,9 @@ class TimingSegment(object):
             if len(seq_indx):
                 this_sub_call = self.sequenceDef[seq_indx[0]][1]
                 match = re.search(
-                    "(IF\s+(?P<N0>!)?(?P<P0>\w+)(?P<D0>--)?\s+)?"
-                    + "((?P<CMD>RETURN|GOTO|CALL)\s+(?P<TS>\w+)\(?)?"
-                    + "(\(?(?P<P1>\w+)?(?P<D1>--)?)\)?",
+                    r"(IF\s+(?P<N0>!)?(?P<P0>\w+)(?P<D0>--)?\s+)?"
+                    + r"((?P<CMD>RETURN|GOTO|CALL)\s+(?P<TS>\w+)\(?)?"
+                    + r"(\(?(?P<P1>\w+)?(?P<D1>--)?)\)?",
                     this_sub_call,
                 )
                 #  REGEX labels:
@@ -1029,7 +1029,7 @@ class TimingSegment(object):
                 axes[kk].grid("on")
                 if kk > 0:
                     axes[kk].set_xticklabels([])
-            axes[0].set_xlabel("time [$\mu$s]")
+            axes[0].set_xlabel(r"time [$\mu$s]")
             axes[kk].set_title("non-static waveforms for %s" % self.name)
             plt.draw()
         print("(Figure %d)" % self.label, end=" ")


### PR DESCRIPTION
To avoid warnings when using Python3, use raw strings when using the re library