### PR TITLE
fix (very bad) typo in pyproject.toml definition

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ version_file = "wdl/_version.py"
 
 [project]
 name = "wdl"
-dyanmic = ["version"]
+dynamic = ["version"]
 
 description = "WDL (Waveform Definition Language) is designed for use with Archons. This library provides tools and instructions for setting up and using WDL efficiently."
 authors = [{name = "Caltech Optical Observatories"}]


### PR DESCRIPTION
unfortunate typo in the commit I added to the previous (v0.1) branch which prevents editable installs. 

Not sure how it slipped through, suggest merge this then re-tag.
I'd typed the same code in my feature branch and probably just mistyped it, sorry