### PR TITLE
Handle special sequence "Start" that does not require an exit.

### DIFF
--- a/wdl/wdlParser.py
+++ b/wdl/wdlParser.py
@@ -2261,7 +2261,7 @@ def generic_sequence(*sequenceName):
         if len(sequence_line) > 0:
             output_text += sequence_line + "\n"
     # do we have an exit from this sequence?
-    if not has_exit:
+    if not has_exit and not 'Start' in sequenceName:
         error("(wdlParser.py::generic_sequence) no exit from sequence "
               + sequenceName[0])
     # sequence/waveform must end with a close (right) curly brace, }

--- a/wdl/wdlParser.py
+++ b/wdl/wdlParser.py
@@ -2261,6 +2261,7 @@ def generic_sequence(*sequenceName):
         if len(sequence_line) > 0:
             output_text += sequence_line + "\n"
     # do we have an exit from this sequence?
+    # exception for special "Start" sequence
     if not has_exit and not 'Start' in sequenceName:
         error("(wdlParser.py::generic_sequence) no exit from sequence "
               + sequenceName[0])


### PR DESCRIPTION
Found while trying to compile ZTF wdl files.  The sequence "Start" in the *.seq file was throwing an error because it has no proper exit (GOTO, RETURN).  In the ZTF files, this "Start" sequence was expected to fall through to the subsequent sequence.  Properly, it should explicitly GOTO that subsequence sequence, however, to make wdl compatible with ZTF files, we are adding an exception for the special sequence "Start".