### PR TITLE
Fixed issue with placeholder val of 1.0e18

### DIFF
--- a/wdl/wavgen.py
+++ b/wdl/wavgen.py
@@ -185,7 +185,7 @@ def loadWDL(infile, outfile="/dev/null", verbose=1):
                             # a const name used as the SET...TO level: give
                             # it a unique placeholder (see __constLevels__)
                             if rawlevel not in __constLevels__:
-                                placeholder = -1.0e18 - len(__constLevels__)
+                                placeholder = -1.0e9 - len(__constLevels__)
                                 __constLevels__[rawlevel] = placeholder
                                 __constLevels__[placeholder] = rawlevel
                             value = __constLevels__[rawlevel]


### PR DESCRIPTION
Not all constants were being generated properly in STATES, I think this was due to the placeholder base value -1.0e18 was outside the range where 64-bit floats can represent integer offsets exactly 

Seemed to cause a bug where all rounded to the identical float value, so every new constant silently overwrote the previous one's entry in the reverse-lookup dict. Only the last one registered survived and got printed everywhere it is used